### PR TITLE
Feature/dockerfile v1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
-FROM httpd:2.4.37
+FROM ubuntu:18.04
+
+LABEL   maintainer="Dejan Stamenov" \
+        maintainer_email="stamenov.dejan@outlook.com"
+
+RUN apt-get update && apt-get install -y apache2 && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 80/tcp
 EXPOSE 8080/tcp
+
+CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ LABEL   maintainer="Dejan Stamenov" \
 
 RUN apt-get update && apt-get install -y apache2 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+ENV APACHE_RUN_USER www-data
+ENV APACHE_RUN_GROUP www-data
+ENV APACHE_LOG_DIR /var/log/apache2
+
 EXPOSE 80/tcp
 EXPOSE 8080/tcp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@ LABEL   maintainer="Dejan Stamenov" \
 
 RUN apt-get update && apt-get install -y apache2 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV APACHE_RUN_USER www-data
-ENV APACHE_RUN_GROUP www-data
-ENV APACHE_LOG_DIR /var/log/apache2
+#ENV APACHE_RUN_USER www-data
+#ENV APACHE_RUN_GROUP www-data
+#ENV APACHE_LOG_DIR /var/log/apache2
 
 EXPOSE 80/tcp
 EXPOSE 8080/tcp
 
-CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]
+#CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]
+CMD ["apachectl", "-D", "FOREGROUND"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ LABEL   maintainer="Dejan Stamenov" \
 
 RUN apt-get update && apt-get install -y apache2 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-#ENV APACHE_RUN_USER www-data
-#ENV APACHE_RUN_GROUP www-data
-#ENV APACHE_LOG_DIR /var/log/apache2
+ENV APACHE_RUN_USER www-data
+ENV APACHE_RUN_GROUP www-data
+ENV APACHE_LOG_DIR /var/log/apache2
 
 EXPOSE 80/tcp
-EXPOSE 8080/tcp
+# To expose 8080/tcp port on the Apache server, the following files must be modified:
+#   - /etc/apache2/ports.conf
+#   - /etc/apache2/sites-enabled/000-default.conf
+#EXPOSE 8080/tcp
 
-#CMD ["/usr/sbin/apache2", "-D", "FOREGROUND"]
 CMD ["apachectl", "-D", "FOREGROUND"]


### PR DESCRIPTION
Merging the **Dockerfile** **v1.0** to the master branch. It is now based on **ubuntu:18.04**, using **apache2**. The Apache2 service is working with port _80/tcp_. Additional configuration is needed so that the service is able to work on port _8080/tcp_.